### PR TITLE
Try installing latest NCBI BLAST+ 2.6.0 via conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,16 @@ FROM andrewosh/binder-base
 
 USER root
 
-# Add dependency
-RUN apt-get update
-RUN apt-get install -y ncbi-blast+
+# Add dependencies using conda and the bioconda channel
+# https://bioconda.github.io/#set-up-channels
+RUN conda config --add channels conda-forge
+RUN conda config --add channels defaults
+RUN conda config --add channels r
+RUN conda config --add channels bioconda
+
+# Install NCBI BLAST+ 2.6.0 using conda
+# https://anaconda.org/bioconda/blast
+conda install -c bioconda blast=2.6.0
 
 USER main
 


### PR DESCRIPTION
I wrote this a while back but didn't submit the PR till today.

It seems Docker base image ``andrewosh/binder-base`` lacks documentation, but from searching on GitHub multiple projects are using it and it appears to come with conda installed.

https://hub.docker.com/r/andrewosh/binder-base/

So we can use that to install the latest BLAST+ with conda, rather than whatever comes with the Docker image via ``apt-get``

NOTE: This pull request does not touch ``install-apps.sh``, see alternative pull request removing the BLAST+ install from ``Dockerfile`` and making it execute ``install-apps.sh`` instead.