### PR TITLE
Link install-apps.sh into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ USER root
 
 # Add dependency
 RUN apt-get update
-RUN apt-get install -y ncbi-blast+
+
+# Install other dependencies via apt-get
+RUN $HOME/install-apps.sh
 
 USER main
 

--- a/install-apps.sh
+++ b/install-apps.sh
@@ -7,25 +7,25 @@
 
 # Update package management
 apt-get update
-apt-get install aptitude
+apt-get install -y aptitude
 
 # Version control
-apt-get install git
+apt-get install -y git
 
 # Browser
-apt-get install google-chrome
+apt-get install -y google-chrome
 
 # SSH access
-apt-get install openssh-server
+apt-get install -y openssh-server
 
 # Markdown conversion
-apt-get install pandoc
+apt-get install -y pandoc
 
 # Visualisation tools
-apt-get install act artemis jmol pymol
+apt-get install -y act artemis jmol pymol
 
 # Sequence search/alignment packages
-apt-get install ncbi-blast+ clustalo hmmer muscle t-coffee
+apt-get install -y ncbi-blast+ clustalo hmmer muscle t-coffee
 
 # Programming tools
-apt-get install python3.6 python3.6-dev virtualenv
+apt-get install -y python3.6 python3.6-dev virtualenv


### PR DESCRIPTION
Removes duplicated installation of NCBI BLAST+ with apt-get by calling ``install-apps.sh`` from the Docker file.

Might we want to add the ``-y`` to ``install-apps.sh``?

(Clashes with #4 which explores using BioConda over apt-get to install NCBI BLAST+)