### PR TITLE
Avoid os.path.join and missing output directory

### DIFF
--- a/02-sequence_databases/07-uniprot_programming.ipynb
+++ b/02-sequence_databases/07-uniprot_programming.ipynb
@@ -92,7 +92,6 @@
     "\n",
     "# Standard library packages\n",
     "import io\n",
-    "import os\n",
     "\n",
     "# Import Seaborn for graphics and plotting\n",
     "import seaborn as sns\n",
@@ -678,7 +677,7 @@
     "result = service.search(query, frmt=\"xls\")\n",
     "\n",
     "# Write the Excel spreadsheet to file\n",
-    "outfile = os.path.join('output', 'uniprot', 'Q01844.xlsx')\n",
+    "outfile = 'output/uniprot/Q01844.xlsx'\n",
     "with open(outfile, 'wb') as ofh:\n",
     "    ofh.write(result)"
    ]

--- a/02-sequence_databases/output/uniprot/README.md
+++ b/02-sequence_databases/output/uniprot/README.md
@@ -1,0 +1,3 @@
+# README.md - `output/uniprot`
+
+This file is a placeholder in the `output/uniprot` directory. This directory should be empty in the repository, but populated as students work through the lessons.

--- a/03-lipases/XX-runthrough.ipynb
+++ b/03-lipases/XX-runthrough.ipynb
@@ -121,9 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -168,8 +166,8 @@
    ],
    "source": [
     "# Read the wildtype and engineered sequences in from file\n",
-    "wildtype = SeqIO.read(os.path.join('data', 'wildtype_nt.fasta'), 'fasta')\n",
-    "engineered = SeqIO.read(os.path.join('data', 'engineered_nt.fasta'), 'fasta')\n",
+    "wildtype = SeqIO.read('data/wildtype_nt.fasta', 'fasta')\n",
+    "engineered = SeqIO.read('data/engineered_nt.fasta', 'fasta')\n",
     "\n",
     "# Show the sequences\n",
     "print(wildtype.format('fasta'))\n",
@@ -232,7 +230,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Convert nucleotide sequences to protein (use table 11)**\n",
     "* **Note that sequence IDs can't have spaces**\n",
@@ -242,7 +243,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "The nucleotide sequences are translated into predicted gene products using the `Biopython` `translate()` method, with translation table 11 (bacteria, archaea, plant plastid). \n",
@@ -253,7 +257,9 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -295,7 +301,9 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -316,7 +324,9 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -340,7 +350,9 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -355,14 +367,17 @@
     }
    ],
    "source": [
-    "# Write sequences to file\n",
-    "SeqIO.write(wildtype_aa, os.path.join(\"output\", \"wildtype_aa.fasta\"), \"fasta\")\n",
-    "SeqIO.write(engineered_aa, os.path.join(\"output\", \"engineered_aa.fasta\"), \"fasta\")"
+    "# Write sequences to FASTA files in output sub-directory\n",
+    "SeqIO.write(wildtype_aa, \"output/wildtype_aa.fasta\", \"fasta\")\n",
+    "SeqIO.write(engineered_aa, \"output/engineered_aa.fasta\", \"fasta\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "This produces conceptual translations of 307aa in length, with 14 residue substitutions between wild-type and engineered forms. These sequences were written to `output/wildtype_aa.fasta` and `output/engineered_aa.fasta`.\n",
@@ -371,7 +386,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## 01b - Identifying a gene model\n",
     "\n",
@@ -383,7 +401,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "The following local `BLAST` databases of the <i>P. mirabilis</i> reference genome are created in the `output` directory, with the names:\n",
@@ -399,7 +420,9 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -464,14 +487,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **However the BLAST search is run, note the utility of having an informative output filename**"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "A `BLASTN` search using the wildtype sequence as query was carried out against the `ref_genome` database to identify a likely genomic location.\n",
@@ -484,7 +513,9 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -510,7 +541,9 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -524,10 +557,10 @@
    ],
    "source": [
     "# Create BLASTN command line\n",
-    "cmd_blastn = NcbiblastnCommandline(query=os.path.join(\"data\", \"wildtype_nt.fasta\"),\n",
-    "                                   db=os.path.join(\"output\", \"ref_genome\"),\n",
+    "cmd_blastn = NcbiblastnCommandline(query=\"data/wildtype_nt.fasta\",\n",
+    "                                   db=\"output/ref_genome\",\n",
     "                                   outfmt=6,\n",
-    "                                   out=os.path.join(\"output\", \"wildtype_blastn_ref_genome.tab\"))\n",
+    "                                   out=\"output/wildtype_blastn_ref_genome.tab\")\n",
     "\n",
     "# Run BLASTN command\n",
     "stdout, stderr = cmd_blastn()\n",
@@ -537,7 +570,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Check the output file. This search provides no matches!**\n",
     "* **Ask the learners to consider a different approach - guide them towards `TBLASTX` (translated query, translated subject)**"
@@ -545,7 +581,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "As the `BLASTN` search produced no matches, a `TBLASTX` search was used, with the same input sequence and database.\n",
@@ -558,7 +597,9 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -572,7 +613,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "**Option 2: notebook search**"
    ]
@@ -581,7 +625,9 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -595,10 +641,10 @@
    ],
    "source": [
     "# Create TBLASTX command line\n",
-    "cmd_tblastx = NcbitblastxCommandline(query=os.path.join(\"data\", \"wildtype_nt.fasta\"),\n",
-    "                                    db=os.path.join(\"output\", \"ref_genome\"),\n",
-    "                                    outfmt=6,\n",
-    "                                    out=os.path.join(\"output\", \"wildtype_tblastx_ref_genome.tab\"))\n",
+    "cmd_tblastx = NcbitblastxCommandline(query=\"data/wildtype_nt.fasta\",\n",
+    "                                     db=\"output/ref_genome\",\n",
+    "                                     outfmt=6,\n",
+    "                                     out=\"output/wildtype_tblastx_ref_genome.tab\")\n",
     "\n",
     "# Run BLASTN command\n",
     "stdout, stderr = cmd_tblastx()\n",
@@ -608,7 +654,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Ask the learners to read in the output file using `pandas`, and present the matches with appropriate headers and a comment.**"
    ]
@@ -617,7 +666,9 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -887,7 +938,7 @@
     "           'e_value', 'bitscore']\n",
     "\n",
     "# Read TBLASTX output and add headers\n",
-    "results = pd.read_csv(os.path.join(\"output\", \"wildtype_tblastx_ref_genome.tab\"), sep=\"\\t\", header=None)\n",
+    "results = pd.read_csv(\"output/wildtype_tblastx_ref_genome.tab\", sep=\"\\t\", header=None)\n",
     "results.columns = headers\n",
     "\n",
     "# Show results\n",
@@ -896,7 +947,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "This query produced a number of candidate genomic region matches. The best match was to the region 1063060-1063941, covering 294 amino acids, at 98.6% identity. This match was taken to be the most likely genomic location for the wildtype sequence.\n",
@@ -905,14 +959,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Ask the learners to search the annotated proteins from the reference, as for the genome search, and summarise the results in a similar way.**"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "A `BLASTX` search using the wildtype sequence as query was carried out against the `ref_protein` database to identify whether a corresponding protein has been annotated on the reference.\n",
@@ -925,7 +985,9 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -939,7 +1001,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "**Option 2: notebook search**"
    ]
@@ -948,7 +1013,9 @@
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -962,10 +1029,10 @@
    ],
    "source": [
     "# Create BLASTX command line\n",
-    "cmd_blastx = NcbiblastxCommandline(query=os.path.join(\"data\", \"wildtype_nt.fasta\"),\n",
-    "                                   db=os.path.join(\"output\", \"ref_protein\"),\n",
+    "cmd_blastx = NcbiblastxCommandline(query=\"data/wildtype_nt.fasta\",\n",
+    "                                   db=\"output/ref_protein\",\n",
     "                                   outfmt=6,\n",
-    "                                   out=os.path.join(\"output\", \"wildtype_blastx_ref_protein.tab\"))\n",
+    "                                   out=\"output/wildtype_blastx_ref_protein.tab\")\n",
     "\n",
     "# Run BLASTN command\n",
     "stdout, stderr = cmd_blastx()\n",
@@ -975,7 +1042,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Remind the learners that they can reuse the headers they defined earlier, when presenting the results as a `pandas` dataframe**"
    ]
@@ -984,7 +1054,9 @@
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -1146,7 +1218,7 @@
    ],
    "source": [
     "# Read TBLASTX output and add headers\n",
-    "results = pd.read_csv(os.path.join(\"output\", \"wildtype_blastx_ref_protein.tab\"), sep=\"\\t\", header=None)\n",
+    "results = pd.read_csv(\"output/wildtype_blastx_ref_protein.tab\", sep=\"\\t\", header=None)\n",
     "results.columns = headers\n",
     "\n",
     "# Show results\n",
@@ -1155,7 +1227,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "The `BLASTX` search showed similarity of the wildtype sequence to seven candidate proteins, but only one candidate, `CAR42190.1`, had more than 30% sequence identity over a considerable part of the sequence.\n",
@@ -1164,7 +1239,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## 01c - Identifying a putative regulatory region\n",
     "\n",
@@ -1191,7 +1269,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Ask learners to write up their work.**\n",
     "\n",
@@ -1203,14 +1284,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## 02 - Identifying homologues in public databases"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### 02a - BLAST/NCBI\n",
     "\n",
@@ -1225,7 +1312,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "The translated wildtype sequence was used as a remote `BLASTP` query against the `nr` database at NCBI. The query was restricted to organisms in the Genus *Proteus*.\n",
@@ -1238,7 +1328,9 @@
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -1253,7 +1345,9 @@
    "cell_type": "code",
    "execution_count": 20,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -2291,14 +2385,17 @@
     "print(output)\n",
     "\n",
     "# Save output to file\n",
-    "outfilename = os.path.join(\"output\", \"wildtype_remote_blastp_nr.txt\")\n",
+    "outfilename = \"output/wildtype_remote_blastp_nr.txt\"\n",
     "with open(outfilename, 'w') as outfh:\n",
     "    outfh.write(output)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Option 2: in the browser**\n",
     "\n",
@@ -2324,7 +2421,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### 02b - UniProt\n",
     "\n",
@@ -2333,7 +2433,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "The `PMI0999` sequence obtained in the `BLAST` search is identifcal to the wildtype, so this accession was used as a query against `UniProt` to identify database cross-links and functional information.\n",
@@ -2347,7 +2450,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Option 2: in the notebook**\n",
     "\n",
@@ -2358,7 +2464,9 @@
    "cell_type": "code",
    "execution_count": 21,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -2385,7 +2493,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Ask the learners to obtain the `pandas` dataframe result for this accession**"
    ]
@@ -2394,7 +2505,9 @@
    "cell_type": "code",
    "execution_count": 22,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -2500,7 +2613,9 @@
    "cell_type": "code",
    "execution_count": 23,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -2544,7 +2659,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "The `PMI0999` accession corresponds to `UniProt` entry `B4EVM3`, an unreviewed putative lipase from *Proteus mirabilis*. Database crossreferences include:\n",
@@ -2567,7 +2685,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### 02c - KEGG\n",
     "\n",
@@ -2583,7 +2704,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "**Option 1: in the browser**\n",
     "\n",
@@ -2602,7 +2726,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "**Option 2: in the notebook**\n",
     "\n",
@@ -2613,7 +2740,9 @@
    "cell_type": "code",
    "execution_count": 24,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -2626,7 +2755,9 @@
    "cell_type": "code",
    "execution_count": 25,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -2671,7 +2802,9 @@
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -2737,7 +2870,9 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -2789,6 +2924,8 @@
    "execution_count": 28,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": true
    },
    "outputs": [
@@ -2893,7 +3030,9 @@
    "cell_type": "code",
    "execution_count": 29,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -2916,7 +3055,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "This lipase is involved in *P. mirabilis* central metabolism (`KEGG: pmr01100`), and specifically glycerolipid metabolism, where it converts between mono, di- and tri-acylglycerols, and fatty acids.\n",
@@ -2925,7 +3067,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Ask the learners to identify sequences in the KEGG KO database corresponding to the wildtype lipase**\n",
     "\n",
@@ -2942,7 +3087,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "**Option 2: in the notebook**"
    ]
@@ -2951,7 +3099,9 @@
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -3734,7 +3884,9 @@
    "cell_type": "code",
    "execution_count": 31,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -3810,7 +3962,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<div class=\"alert-success\">\n",
     "The *P. mirabilis* lipase is a member of the KEGG orthologue group `KO1046`, which contains 1043 members. There appears to be a large extent of diversity to draw upon for directed evolution and engineering experiments.\n",
@@ -3819,7 +3974,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### 02d - Generate an orthologue/homologue set\n",
     "\n",
@@ -3836,12 +3994,14 @@
    "cell_type": "code",
    "execution_count": 32,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
     "# Get protein sequences for the first 90 KO group members\n",
-    "with open(os.path.join(\"output\", \"kegg_orthologues.fasta\"), \"w\") as ko_handle:\n",
+    "with open(\"output/kegg_orthologues.fasta\", \"w\") as ko_handle:\n",
     "    for kegg_id in orthologues[0][:90]:\n",
     "        result = REST.kegg_get(kegg_id, \"aaseq\").read()\n",
     "        ko_handle.write(result)"
@@ -3849,7 +4009,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "* **Ask the learners to open Jalview and load in the `kegg_orthologues.fasta` file**\n",
     "* **Ask the learners to submit an alignment job to a webservice**\n",
@@ -3859,21 +4022,30 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## 03 - Identifying related structural data"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## 04 - Comparing engineered to wild-type sequence"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## 05 - Generating a shareable document\n",
     "\n",
@@ -3892,7 +4064,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": []


### PR DESCRIPTION
Partly addresses #49 (remaining cases are combining directory names in variables with filenames), and also solves #52 which came up while testing this.